### PR TITLE
Minimal working example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tags
 *.pyc
+config.yaml

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Martijn Hemeryck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # covers
 
 Maps covers from home assistant to relays on unipi.
+
+## Example config file
+
+The config file is supposed to be in this format:
+
+    office_side:
+      open:
+        input: "3_11"
+        relay: "3_14"
+      close:
+        input: "3_12"
+        relay: "3_13"
+    office_front:
+      open:
+        input: "3_09"
+        relay: "3_11"
+      close:
+        input: "3_10"
+        relay: "3_12"

--- a/covers.py
+++ b/covers.py
@@ -1,0 +1,343 @@
+import argparse
+import logging
+import logging.config
+import re
+import sys
+import threading
+import time
+import typing
+
+import paho.mqtt.client as mqtt
+import yaml
+
+LOG_LEVEL = logging.INFO
+LOG_CONFIG = dict(
+    version=1,
+    formatters={"default": {"format": "%(asctime)s - %(levelname)s - %(message)s"}},
+    handlers={
+        "stream": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+            "level": LOG_LEVEL,
+        }
+    },
+    root={"handlers": ["stream"], "level": LOG_LEVEL},
+)
+logging.config.dictConfig(LOG_CONFIG)
+logger = logging.getLogger(__name__)
+
+
+class ACTION:
+    """enum for actions"""
+
+    COMMAND = "set"
+    STATE = "state"
+
+
+class OP:
+    """enum for expected operations"""
+
+    OPEN = "open"
+    CLOSE = "close"
+
+
+class ENTITY:
+    """enum for types of entities"""
+
+    INPUT = "input"
+    RELAY = "relay"
+
+
+class COVER_STATE:
+    """enum to describe what the cover is currently doing"""
+
+    OPENING = "opening"
+    STILL = "still"
+    CLOSING = "closing"
+
+
+class PAYLOAD:
+    """payload values"""
+
+    ON = b"ON"
+    OFF = b"OFF"
+
+
+TOPIC_FORMAT = "{base_topic}/{entity_type}/{name}/{action}"
+TOPIC_REGEX = re.compile(
+    r"^(?P<base_topic>\w+)/(?P<entity_type>(input|relay))/(?P<name>\w+)/state$"
+)
+
+
+def cleanup(topic: str, on_time: int) -> None:
+    """Shutdown the relay in a separate thread after max time"""
+    time.sleep(on_time)
+    client.publish(topic, PAYLOAD.OFF)
+
+
+def on_message_input(
+    client: mqtt.Client,
+    userdata: typing.Union[None, typing.Dict],
+    message: mqtt.MQTTMessage,
+):
+    """Callback for MQTT events"""
+    logger.info(f"Handle input message {message.payload} for topic {message.topic}")
+
+    # Ignore trailing edges
+    if message.payload != PAYLOAD.ON:
+        return
+
+    # Match input
+    match = TOPIC_REGEX.match(message.topic)
+
+    # Nothing found, just break off
+    if match is None:
+        return
+
+    name = match.group("name")
+    cover_name = userdata["input_map"][name]["name"]
+    relay_name = userdata["input_map"][name]["relay"]
+    input_op = userdata["input_map"][name]["op"]
+
+    # Get current state
+    cover_state = userdata["cover_state"].get(cover_name)
+    if not cover_state:
+        return
+
+    topic = TOPIC_FORMAT.format(
+        base_topic=userdata["relays_base_topic"],
+        entity_type=ENTITY.RELAY,
+        name=relay_name,
+        action=ACTION.COMMAND,
+    )
+
+    # Check transitions
+    if input_op == OP.OPEN and cover_state == COVER_STATE.STILL:
+        client.publish(topic, PAYLOAD.ON)
+    elif input_op == OP.OPEN and cover_state == COVER_STATE.CLOSING:
+        # Can't happen, just stop everything to be sure
+        client.publish(topic, PAYLOAD.OFF)
+        relay_name = userdata["config"][cover_name][OP.CLOSE]["relay"]
+        topic = TOPIC_FORMAT.format(
+            base_topic=userdata["relays_base_topic"],
+            entity_type=ENTITY.RELAY,
+            name=relay_name,
+            action=ACTION.COMMAND,
+        )
+        client.publish(topic, PAYLOAD.OFF)
+    elif input_op == OP.OPEN and cover_state == COVER_STATE.OPENING:
+        client.publish(topic, PAYLOAD.OFF)
+    elif input_op == OP.CLOSE and cover_state == COVER_STATE.STILL:
+        client.publish(topic, PAYLOAD.ON)
+    elif input_op == OP.CLOSE and cover_state == COVER_STATE.OPENING:
+        # Can't happen, stop just to be sure
+        client.publish(topic, PAYLOAD.OFF)
+        relay_name = userdata["config"][cover_name][OP.OPEN]["relay"]
+        topic = TOPIC_FORMAT.format(
+            base_topic=userdata["relays_base_topic"],
+            entity_type=ENTITY.RELAY,
+            name=relay_name,
+            action=ACTION.COMMAND,
+        )
+        client.publish(topic, PAYLOAD.OFF)
+    elif input_op == OP.CLOSE and cover_state == COVER_STATE.CLOSING:
+        client.publish(topic, PAYLOAD.OFF)
+
+
+def on_message_relay(
+    client: mqtt.Client,
+    userdata: typing.Union[None, typing.Dict],
+    message: mqtt.MQTTMessage,
+):
+    """Callback for relay MQTT events"""
+    logger.info(f"Handle relay message {message.payload} for topic {message.topic}")
+
+    # Match input
+    match = TOPIC_REGEX.match(message.topic)
+
+    # Nothing found, just break off
+    if match is None:
+        return
+
+    name = match.group("name")
+    cover_name = userdata["relay_map"][name]["name"]
+    relay_op = userdata["relay_map"][name]["op"]
+
+    # Update global state
+    if relay_op == OP.OPEN and message.payload == PAYLOAD.ON:
+        userdata["cover_state"][cover_name] = COVER_STATE.OPENING
+    elif relay_op == OP.OPEN and message.payload == PAYLOAD.OFF:
+        userdata["cover_state"][cover_name] = COVER_STATE.STILL
+    elif relay_op == OP.CLOSE and message.payload == PAYLOAD.OFF:
+        userdata["cover_state"][cover_name] = COVER_STATE.STILL
+    elif relay_op == OP.CLOSE and message.payload == PAYLOAD.ON:
+        userdata["cover_state"][cover_name] = COVER_STATE.CLOSING
+
+    # Make sure the relays don't stay on too long, in a separate fire-and-forget thread
+    if message.payload == PAYLOAD.ON:
+        topic = TOPIC_FORMAT.format(
+            base_topic=userdata["relays_base_topic"],
+            entity_type=ENTITY.RELAY,
+            name=name,
+            action=ACTION.COMMAND,
+        )
+        threading.Thread(
+            target=cleanup,
+            args=(topic, userdata["on_time"]),
+            daemon=True,
+        ).start()
+
+    return
+
+
+def on_connect(
+    client: mqtt.Client,
+    userdata: typing.Union[None, typing.Dict],
+    flags: typing.Dict,
+    rc: int,
+):
+    """Callback for when MQTT connection to broker is set up"""
+    logger.info("Subscribe to all state topics ...")
+    for relay_name, relay_map in userdata["config"].items():
+        for op, entity_map in relay_map.items():
+            for entity_type, entity_name in entity_map.items():
+                if entity_type == ENTITY.INPUT:
+                    topic = TOPIC_FORMAT.format(
+                        base_topic=userdata["inputs_base_topic"],
+                        entity_type=entity_type,
+                        name=entity_name,
+                        action=ACTION.STATE,
+                    )
+                    client.message_callback_add(topic, on_message_input)
+                elif entity_type == ENTITY.RELAY:
+                    topic = TOPIC_FORMAT.format(
+                        base_topic=userdata["relays_base_topic"],
+                        entity_type=entity_type,
+                        name=entity_name,
+                        action=ACTION.STATE,
+                    )
+                    client.message_callback_add(topic, on_message_relay)
+                else:
+                    logger.warning(f"Unknown entity type {entity_type}")
+                    return
+                logger.info(
+                    f"Subscribe to topic {topic} for {relay_name}-{op}-{entity_type}"
+                )
+                client.subscribe(topic)
+
+
+def is_config_valid(
+    config: typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]]
+) -> bool:
+    """Check whether config is expected format"""
+    for relay_name, relay_map in config.items():
+        for op, entity_map in relay_map.items():
+            if op not in (OP.OPEN, OP.CLOSE):
+                logger.warning(f"Found invalid op {op} in config")
+                return False
+            for entity_type, entity_name in entity_map.items():
+                if entity_type not in (ENTITY.INPUT, ENTITY.RELAY):
+                    logger.warning(f"Found invalid entity type {entity_type} in config")
+                    return False
+        if relay_map[OP.OPEN][ENTITY.INPUT] == relay_map[OP.CLOSE][ENTITY.INPUT]:
+            logger.warning(f"Found duplicate input entity in config for {relay_name}")
+            return False
+        if relay_map[OP.OPEN][ENTITY.RELAY] == relay_map[OP.CLOSE][ENTITY.RELAY]:
+            logger.warning(f"Found duplicate relay entity in config for {relay_name}")
+            return False
+    return True
+
+
+def input_map(
+    config: typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]]
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    """Builds an easy mapping for inputs to the cover details"""
+    mapping = {}
+    for relay_name, relay_map in config.items():
+        mapping[relay_map[OP.OPEN][ENTITY.INPUT]] = {
+            "name": relay_name,
+            "op": OP.OPEN,
+            "relay": relay_map[OP.OPEN][ENTITY.RELAY],
+        }
+        mapping[relay_map[OP.CLOSE][ENTITY.INPUT]] = {
+            "name": relay_name,
+            "op": OP.CLOSE,
+            "relay": relay_map[OP.CLOSE][ENTITY.RELAY],
+        }
+    return mapping
+
+
+def relay_map(
+    config: typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]]
+) -> typing.Dict[str, typing.Dict[str, str]]:
+    """Builds an easy mapping for outputs to the cover details"""
+    mapping = {}
+    for relay_name, relay_map in config.items():
+        mapping[relay_map[OP.OPEN][ENTITY.RELAY]] = {
+            "name": relay_name,
+            "op": OP.OPEN,
+        }
+        mapping[relay_map[OP.CLOSE][ENTITY.RELAY]] = {
+            "name": relay_name,
+            "op": OP.CLOSE,
+        }
+    return mapping
+
+
+def init_cover_state(
+    config: typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]]
+) -> typing.Dict[str, str]:
+    """Keeps the global state of the covers"""
+    return {cover_name: COVER_STATE.STILL for cover_name in config.keys()}
+
+
+if __name__ == "__main__":
+    # Parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mqtt_host", help="MQTT broker host")
+    parser.add_argument("config", help="YAML config file")
+    parser.add_argument("inputs_base_topic", help="Base topic of device connecting to")
+    parser.add_argument("relays_base_topic", default="shady", help="Relay base topic")
+    parser.add_argument("--mqtt_port", type=int, default=1883)
+    parser.add_argument(
+        "--mqtt_client_id", help="Client ID to use for MQTT", default="covers"
+    )
+    parser.add_argument(
+        "--on_time",
+        type=int,
+        default=30,
+        help="Time in seconds the cover relays can on",
+    )
+    args = parser.parse_args()
+
+    # read config
+    with open(args.config, "r") as fh:
+        config = yaml.safe_load(fh)
+
+    # Validate
+    if not is_config_valid(config):
+        logger.warning("Found error in config, not starting ...")
+        sys.exit(1)
+
+    # MQTT initial setup
+    logger.info(f"Connecting to MQTT broker {args.mqtt_host}")
+    client = mqtt.Client(
+        client_id=args.mqtt_client_id,
+        clean_session=None,
+        userdata={
+            "relays_base_topic": args.relays_base_topic,
+            "inputs_base_topic": args.inputs_base_topic,
+            "config": config,
+            "input_map": input_map(config),
+            "relay_map": relay_map(config),
+            "cover_state": init_cover_state(config),
+            "on_time": args.on_time,
+        },
+    )
+    client.on_connect = on_connect
+    client.connect(args.mqtt_host, args.mqtt_port, 60)
+    client.enable_logger(logger=logger)
+
+    # Loop
+    logger.info("Starting MQTT loop")
+    client.loop_forever()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,51 @@
+[[package]]
+name = "paho-mqtt"
+version = "1.5.1"
+description = "MQTT version 5.0/3.1.1 client class"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+proxy = ["pysocks"]
+
+[[package]]
+name = "pyyaml"
+version = "5.4.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "bd310239e6902d40a640404a6d48b87a745cc4fa42c32f25f7051d06f825358c"
+
+[metadata.files]
+paho-mqtt = [
+    {file = "paho-mqtt-1.5.1.tar.gz", hash = "sha256:9feb068e822be7b3a116324e01fb6028eb1d66412bf98595ae72698965cb1cae"},
+]
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.9"
 paho-mqtt = "^1.5.1"
+PyYAML = "^5.4.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Single python module for matching inputs to relays, all based on MQTT.

The topic naming is heavily inspired from home assistant https://www.home-assistant.io/integrations/mqtt/ even though there's no direct link to home assistant here.

The inputs and relays are from the unipi platform, which each run an instance of evok2mqtt, see https://github.com/mhemeryck/evok2mqtt

Included here:
1. config validation
2. config parsing
3. registering against topics based on the parsed config
4. callbacks for input buttons, including guarding the relays from running both at the same time for the same cover
5. callbacks for state changes on the relays including automatically stopping the relays